### PR TITLE
consider empy xlink(entry)

### DIFF
--- a/src/bibliography.jl
+++ b/src/bibliography.jl
@@ -50,11 +50,18 @@ function Selectors.runner(::Type{BibliographyBlock}, x, page, doc)
         link = xlink(entry)
         title = xtitle(entry) |> tex2unicode
         published_in = xin(entry)
-
-        entry_text = """<dt>$id</dt>
-        <dd>
-          <div id="$id">$authors ($year), <a href="$link">$title</a>, $published_in</a>
-        </dd>"""
+        
+        if isempty(link)
+            entry_text = """<dt>$id</dt>
+            <dd>
+              <div id="$id">$authors ($year), $title, $published_in</a>
+            </dd>"""
+        else
+            entry_text = """<dt>$id</dt>
+            <dd>
+              <div id="$id">$authors ($year), <a href="$link">$title</a>, $published_in</a>
+            </dd>"""
+        end
         raw_bib *= entry_text
     end
     raw_bib *= "\n</dl>"


### PR DESCRIPTION
`link = xlink(entry)` is on some cases empty which leads to "broken/useless links" (see. e.g. [ClimateMachine.jl/latest/References](https://clima.github.io/ClimateMachine.jl/latest/References/)).
The proposed change omits the HTML links on such cases.