### PR TITLE
Small change.

### DIFF
--- a/src/DocumenterCitations.jl
+++ b/src/DocumenterCitations.jl
@@ -16,7 +16,7 @@ using Unicode
 
 export CitationBibliography
 struct CitationBibliography <: Documenter.Plugin
-    bib::OrderedDict{String,Bibliography.Entry}
+    bib::OrderedDict{String,<:Bibliography.AbstractEntry}
 end
 function CitationBibliography(filename::AbstractString = "";
                               sorting::Symbol = :none)


### PR DESCRIPTION
I had overseen that `Bibliography.jl` has a `AbstractEntry` data type.